### PR TITLE
Quiz vo,Service, Controller, CreateQuizRequest, MemberVo,Repository 수정

### DIFF
--- a/Back/mesbiens/src/main/java/mesbiens/community/quiz/controller/CreateQuizRequest.java
+++ b/Back/mesbiens/src/main/java/mesbiens/community/quiz/controller/CreateQuizRequest.java
@@ -1,47 +1,22 @@
 package mesbiens.community.quiz.controller;
 
-import java.time.LocalDateTime;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
-
-
 import lombok.Getter;
 import lombok.Setter;
 import mesbiens.community.quiz.vo.QuizVo;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 public class CreateQuizRequest {
-	
-	private int memberId;
+    private int memberId;
     private QuizVo quizVo;
-    private String quizQuestion;
-    private String quizCorrectAnswer;
-    private String quizHint;
-    private String quizDifficulty;
-    private int quizTotalScore;
-    private int quizCorrectCount;
-    private String quizRank;
+
+   
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime quizLastUpdate;
+    private LocalDateTime quizLastUpdate;  // 필요하다면 이 필드를 추가로 받을 수 있음
 
     // 기본 생성자
     public CreateQuizRequest() {}
-    
-    public int getMemberId() {
-        return memberId;
-    }
-
-    public void setMemberId(int memberId) {
-        this.memberId = memberId;
-    }
-
-    public QuizVo getQuizVo() {
-        return quizVo;
-    }
-
-    public void setQuizVo(QuizVo quizVo) {
-        this.quizVo = quizVo;
-    }
-
 }

--- a/Back/mesbiens/src/main/java/mesbiens/community/quiz/controller/QuizController.java
+++ b/Back/mesbiens/src/main/java/mesbiens/community/quiz/controller/QuizController.java
@@ -1,22 +1,16 @@
 package mesbiens.community.quiz.controller;
 
+import mesbiens.community.quiz.service.QuizService;
+import mesbiens.community.quiz.vo.QuizVo;
+
+
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import mesbiens.community.quiz.service.QuizService;
-import mesbiens.community.quiz.vo.QuizVo;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/quiz")
@@ -33,20 +27,23 @@ public class QuizController {
 
     // 특정 퀴즈 조회
     @GetMapping("/{quizId}")
-    public Optional<QuizVo> getQuizById(@PathVariable int quizId) {
+    public Optional<QuizVo> getQuizById(@PathVariable("quizId") int quizId) {
         return quizService.getQuizById(quizId);
     }
 
     @PostMapping("/create")
-    public ResponseEntity<String> createQuiz(@RequestBody QuizVo quiz) {
-        // quiz 객체를 처리하는 로직
+    public ResponseEntity<String> createQuiz(@RequestBody CreateQuizRequest request) {
+    	// quiz 객체에 필요한 memberId와 quizVo를 전달하여 퀴즈 생성
+        QuizVo quizVo = request.getQuizVo();
+    	
+    	// quiz 객체에 필요한 memberId와 quizVo를 전달하여 퀴즈 생성
+        quizService.createQuiz(request.getMemberId(),quizVo);
         return ResponseEntity.ok("Quiz created successfully!");
     }
 
-
     // 퀴즈 수정
     @PutMapping("/update/{quizId}")
-    public ResponseEntity<QuizVo> updateQuiz(@PathVariable int quizId, @RequestBody QuizVo updatedQuizVo) {
+    public ResponseEntity<QuizVo> updateQuiz(@PathVariable("quizId") int quizId, @RequestBody QuizVo updatedQuizVo) {
         try {
             QuizVo updatedQuiz = quizService.updateQuiz(quizId, updatedQuizVo);
             return ResponseEntity.ok(updatedQuiz);
@@ -57,7 +54,7 @@ public class QuizController {
 
     // 퀴즈 삭제
     @DeleteMapping("/delete/{quizId}")
-    public ResponseEntity<String> deleteQuiz(@PathVariable int quizId) {
+    public ResponseEntity<String> deleteQuiz(@PathVariable("quizId") int quizId) {
         boolean deleted = quizService.deleteQuiz(quizId);
         if (deleted) {
             return ResponseEntity.ok("Quiz deleted successfully");

--- a/Back/mesbiens/src/main/java/mesbiens/community/quiz/service/QuizService.java
+++ b/Back/mesbiens/src/main/java/mesbiens/community/quiz/service/QuizService.java
@@ -1,4 +1,5 @@
 package mesbiens.community.quiz.service;
+
 import mesbiens.community.quiz.repository.QuizRepository;
 import mesbiens.community.quiz.vo.QuizVo;
 import mesbiens.member.repository.MemberRepository;
@@ -8,38 +9,40 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.transaction.Transactional;
-
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
 @Service
 public class QuizService {
-	
-	private static final Logger log = LoggerFactory.getLogger(QuizService.class);
+
+   
 
     @Autowired
     private QuizRepository quizRepository;
-    
+
     @Autowired
     private MemberRepository memberRepository;
+    
+ // 로그 추가
+    private static final Logger logger = LoggerFactory.getLogger(QuizService.class);
 
     // 퀴즈 생성
     @Transactional
-    public QuizVo createQuiz(int memberId,QuizVo quizVo) {
-    	
-    //memberId로 Member 객체를 조회
-      MemberVO member = memberRepository.findById(memberId)
-     .orElseThrow(() -> new RuntimeException("Member not found"));
+    public QuizVo createQuiz(int memberId, QuizVo quizVo) {
+    	 // 로그 추가: memberId로 회원 조회 시도를 기록
+    	 logger.info("Attempting to find member with ID: " + memberId);
 
-    	
-    	 // 새로운 QuizVo 객체 생성
+        // memberId로 Member 객체를 조회 (findByMemberNo 사용)
+        MemberVO member = memberRepository.findByMemberNo(memberId)
+            .orElseThrow(() -> new RuntimeException("Member with ID " + memberId + " not found"));
+
+        logger.info("Member found: " + member.getMemberName());
+        // 새로운 QuizVo 객체 생성
         QuizVo quiz = new QuizVo();
         
-        // 수동으로 ID 값을 설정
-       quiz.setQuizNo(123);; // 예시: ID를 123L로 설정
-
         // quizVo에서 나머지 값들을 설정
         quiz.setQuizQuestion(quizVo.getQuizQuestion());
         quiz.setQuizCorrectAnswer(quizVo.getQuizCorrectAnswer());
@@ -48,19 +51,14 @@ public class QuizService {
         quiz.setQuizTotalScore(quizVo.getQuizTotalScore());
         quiz.setQuizCorrectCount(quizVo.getQuizCorrectCount());
         quiz.setQuizRank(quizVo.getQuizRank());
-        quiz.setQuizLastUpdate(quizVo.getQuizLastUpdate());
         
+        quiz.setQuizCreateAt(new Date());  // 현재 날짜로 퀴즈 생성일 설정
+        quiz.setQuizLastUpdate(new Date());  // 현재 날짜로 마지막 업데이트 설정
         
-
         // quiz 객체에 member 설정
-      //  quiz.setMember(member);
-        
-        QuizVo savedQuiz = quizRepository.save(quiz);
-        log.info("Quiz created successfully with ID: " + savedQuiz.getQuizNo());
+        quiz.setMember(member);
 
-
-        // 퀴즈 저장
-        return savedQuiz;
+        return quizRepository.save(quiz);
     }
 
     // 퀴즈 조회
@@ -79,10 +77,10 @@ public class QuizService {
     }
 
     // 퀴즈 수정
+    @Transactional
     public QuizVo updateQuiz(int quizId, QuizVo updatedQuizVo) {
         Optional<QuizVo> existingQuizOpt = quizRepository.findById(quizId);
         if (existingQuizOpt.isPresent()) {
-        	  
             QuizVo existingQuiz = existingQuizOpt.get();
             existingQuiz.setQuizQuestion(updatedQuizVo.getQuizQuestion());
             existingQuiz.setQuizCorrectAnswer(updatedQuizVo.getQuizCorrectAnswer());
@@ -91,7 +89,7 @@ public class QuizService {
             existingQuiz.setQuizTotalScore(updatedQuizVo.getQuizTotalScore());
             existingQuiz.setQuizCorrectCount(updatedQuizVo.getQuizCorrectCount());
             existingQuiz.setQuizRank(updatedQuizVo.getQuizRank());
-            existingQuiz.setQuizLastUpdate(updatedQuizVo.getQuizLastUpdate());
+            existingQuiz.setQuizLastUpdate(new Date());  // 업데이트 시 마지막 수정일 설정
             return quizRepository.save(existingQuiz);
         } else {
             return null;
@@ -99,6 +97,7 @@ public class QuizService {
     }
 
     // 퀴즈 삭제
+    @Transactional
     public boolean deleteQuiz(int quizId) {
         if (quizRepository.existsById(quizId)) {
             quizRepository.deleteById(quizId);
@@ -107,6 +106,4 @@ public class QuizService {
             return false;
         }
     }
-
-
 }

--- a/Back/mesbiens/src/main/java/mesbiens/community/quiz/vo/QuizVo.java
+++ b/Back/mesbiens/src/main/java/mesbiens/community/quiz/vo/QuizVo.java
@@ -1,5 +1,9 @@
 package mesbiens.community.quiz.vo;
 
+
+/*QUIZ_CORRECT_ANSWER, QUIZ_DIFFICULTY 데이터 타입 크기 1로 설정 되어 있는데
+ 이 컬럼들의 데이터 타입 크기 10정도로 변경하기*/
+
 import java.util.Date;
 
 import jakarta.persistence.Column;
@@ -8,7 +12,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import lombok.Getter;
@@ -20,10 +27,12 @@ import mesbiens.member.vo.MemberVO;
 @Setter
 @Getter
 public class QuizVo {
-	
-	@Id
-	@Column(name = "quiz_no")
-    private int quizNo;  // 퀴즈 ID
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "quiz_seq")  // 자동 증가 시퀀스 사용
+    @SequenceGenerator(name = "quiz_seq", sequenceName = "SEQ_QUIZ_NO", allocationSize = 1)  // 시퀀스 설정
+    @Column(name = "quiz_no")
+    private int quizNo;  // 퀴즈 ID, 자동 증가 필드로 설정
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_no", referencedColumnName = "member_no", nullable = false)
@@ -38,27 +47,23 @@ public class QuizVo {
     @Column(name = "quiz_hint", length = 300)
     private String quizHint;  // 퀴즈 힌트 (nullable)
     
-   
     @Column(name = "quiz_difficulty", nullable = false, length = 1)
     private String quizDifficulty;  // 퀴즈 난이도
 
     @Column(name = "quiz_create_at", nullable = false)
     @Temporal(TemporalType.TIMESTAMP)
-    private Date quizCreateAt;  // 퀴즈 생성일
+    private Date quizCreateAt = new Date();  // 퀴즈 생성일, 현재 날짜로 초기화
 
     @Column(name = "quiz_total_score", nullable = false)
     private int quizTotalScore;  // 퀴즈 총 점수
 
     @Column(name = "quiz_correct_count", nullable = false)
     private int quizCorrectCount;  // 퀴즈 맞춘 개수
-    
-   
 
     @Column(name = "quiz_rank", length = 50)
     private String quizRank;  // 퀴즈 랭크 (nullable)
 
     @Column(name = "quiz_last_update", nullable = false)
     @Temporal(TemporalType.TIMESTAMP)
-    private Date quizLastUpdate;  // 퀴즈 마지막 업데이트 날짜
-
+    private Date quizLastUpdate = new Date();  // 퀴즈 마지막 업데이트 날짜, 현재 날짜로 초기화
 }

--- a/Back/mesbiens/src/main/java/mesbiens/member/repository/MemberRepository.java
+++ b/Back/mesbiens/src/main/java/mesbiens/member/repository/MemberRepository.java
@@ -1,11 +1,12 @@
 package mesbiens.member.repository;
 
-
 import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import mesbiens.member.vo.MemberVO;
 
 public interface MemberRepository extends CrudRepository<MemberVO, Integer> {
-    // findById 메서드는 Long 타입의 ID를 받음
-    Optional<MemberVO> findById(int memberId);
+
+    // 회원 번호(memberNo)를 기준으로 조회하는 메소드
+    Optional<MemberVO> findByMemberNo(int memberNo);
+    
 }

--- a/Back/mesbiens/src/main/java/mesbiens/member/vo/MemberVO.java
+++ b/Back/mesbiens/src/main/java/mesbiens/member/vo/MemberVO.java
@@ -1,11 +1,8 @@
 package mesbiens.member.vo;
 
-
-
 import java.sql.Timestamp;
-
 import org.hibernate.annotations.CreationTimestamp;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -21,6 +18,7 @@ import lombok.Setter;
 
 @Entity
 @Table(name="member")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})//프록시 객체의 직렬화를 방지
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter


### PR DESCRIPTION
QuizVo 수정부분
1. quizNo 필드에 @GeneratedValue와 @SequenceGenerator가 추가되어 quizNo 값이 자동 증가하도록 설정
2. quizCreateAt, quizLastUpdate 필드에 new Date()로 초기값을 설정하여 객체가 생성될 때마다 현재 날짜와 시간으로 자동 초기화

QuizService 수정부분
1. logger 추가 및 로깅(나중에 삭제해도 됨)
1) 수정 후에서 로그를 추가하여, createQuiz 메소드에서 회원 조회 시도와 성공적인 회원 조회 로그를 기록 설정
2) logger.info("Attempting to find member with ID: " + memberId); → 로그 추가
3) logger.info("Member found: " + member.getMemberName()); → 로그 추가

2. findById에서 findByMemberNo로 변경
1) memberRepository.findByMemberNo(memberId) >> memberNo를 기준으로 조회하도록 변경

3.quizCreateAt과 quizLastUpdate 필드의 자동 설정
1) 퀴즈 생성일(quizCreateAt)과 마지막 업데이트일(quizLastUpdate)을 new Date()로 설정하여, 
 퀴즈를 생성할 때 자동으로 현재 날짜를 설정하여, 퀴즈 생성 시간 및 마지막 수정 시간이 기록

4. quizNo ID 수동 설정 제거
1)수정 후에서는 수동 설정이 제거되었으며, quizNo는 데이터베이스에서 자동으로 생성
->quizNo는 데이터베이스에서 자동 증가 시퀀스로 설정되므로 수동 설정이 필요없다

5.quizLastUpdate의 수정 시 자동 날짜 설정
existingQuiz.setQuizLastUpdate(new Date()); >> 퀴즈가 수정될 때마다 마지막 수정 날짜가 자동으로 갱신

QuizController 수정 부분

1.createQuiz 메소드에서 @RequestBody QuizVo quiz → @RequestBody CreateQuizRequest request로 변경
: createQuiz 메소드가 더 이상 QuizVo 객체를 직접 받지 않고, CreateQuizRequest라는 별도의 객체를 받도록 변경 
이 객체는 클라이언트에서 전송되는 memberId와 quizVo를 포함하여 QuizVo와 memberId를 분리하여 처리

2.quizService.createQuiz() 메소드의 호출 변경
quizService.createQuiz(request.getMemberId(), quizVo); 이걸로 변경하여
createQuiz 메소드 호출 시, request.getMemberId()로 memberId를, 
quizVo는 request.getQuizVo()로 전달되도록 변경하고 
memberId와 quizVo가 이제 별도로 전달되며, createQuiz 메소드가 이를 각각 처리하도록 변경

3.퀴즈 조회: (@PathVariable int quizId) -> (@PathVariable("quizId") int quizId)
@PathVariable에 "quizId"를 명시적으로 지정하여, URL 경로에서 quizId 값을 변수 quizId에 할당

4.퀴즈수정: @PathVariable int quizId -> @PathVariable("quizId") int quizId 변경
@PathVariable에 "quizId"를 명시적으로 지정하여, URL 경로에서 quizId 값을 변수 quizId에 할당

5.퀴즈삭제: @PathVariable int quizid -> @PathVariable("quizId") int quizId
@PathVariable에 "quizId"를 명시적으로 지정하여, URL 경로에서 quizId 값을 변수 quizId에 할당

CreateQuizRequest 수정부분
1.quizQuestion, quizCorrectAnswer, quizHint, quizDifficulty, quizTotalScore, quizCorrectCount, quizRank 필드 제거
QuizVo와 중복되던 코드들을 제거하여 QuizVo 객체를 CreateQuizRequest에서 관리하여
퀴즈에 관련된 모든 데이터를 하나의 객체로 전달하도록 변경하여 Quizvo 객체를 CreateQuizRequest사용하여
더 깔끔하게 처리하거나 필요할 때 수정하거나 접근이 가능

2.@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") 주석을 통한 날짜 형식 지정
1)quizLastUpdate 필드에 날짜 형식을 지정하기 위해 @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")가 추가
>>quizLastUpdate 필드가 JSON으로 직렬화될 때, 날짜 형식을 "yyyy-MM-dd'T'HH:mm:ss"로 포맷팅하여 전송하도록 명시
이 코드는 클라이언트와 서버 간 날짜 전달에 일관된 형식을 제공하며, 
JSON 요청이나 응답에서 날짜가 일관되게 처리되도록 돕는다.

MemberVo 수정부분
1.@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"}) 추가
1)@JsonIgnoreProperties 어노테이션은 Jackson 라이브러리를 사용하여 객체를 JSON으로 직렬화할 때 특정 필드나 속성을 무시가능
2)Hibernate 프록시 객체가 JSON으로 변환될 때, 이들 속성들이 포함되지 않도록 방지하는 역할을 합니다.

MemberRepository 수정부분
1.메소드 이름 변경 및 필드 변경
findById -> findByMemberNo 변경
findById(int memberId)는 기본 메소드와 이름이 중복될 수 있기 때문에, 
findByMemberNo(int memberNo)로 변경하여 명확히 회원 번호(memberNo)를 기준으로 조회하는 메소드로 설정